### PR TITLE
Don't strip 'sha256:' prefix from layer ID when comparing

### DIFF
--- a/aurblobs/container.py
+++ b/aurblobs/container.py
@@ -42,7 +42,7 @@ def need_rebuild():
     for layer in image.history():
         if layer['Id'] == "<missing>":
             continue
-        if layer['Id'].split(':', 1)[1].startswith(baseimage_new.id):
+        if layer['Id'].startswith(baseimage_new.id):
             baselayer_found = True
             break
 


### PR DESCRIPTION
This fixes #56 

When comparing two layer IDs we either strip the 'sha256:' from both or we leave it there. Otherwise `.startswith()` will never match and aurblobs will always rebuild.